### PR TITLE
Add a mobile socials drawer

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "rostra": "^1.0.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
+    "vaul": "^1.1.2",
     "zod": "^4.1.11"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
+      vaul:
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       zod:
         specifier: ^4.1.11
         version: 4.1.11
@@ -2339,6 +2342,12 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vaul@1.1.2:
+    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -4811,6 +4820,15 @@ snapshots:
       react: 19.1.4
 
   util-deprecate@1.0.2: {}
+
+  vaul@1.1.2(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.4(react@19.1.4))(react@19.1.4):
+    dependencies:
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      react: 19.1.4
+      react-dom: 19.1.4(react@19.1.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   vfile-message@4.0.3:
     dependencies:

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { SocialsBar } from "@/features/socials/socials-bar";
+import { SocialsSheet } from "@/features/socials/socials-sheet";
 import * as Abyss from "@/atoms/abyss";
 import * as Scroll from "@/atoms/scroll";
 import { Separator } from "@/atoms/separator";
@@ -30,6 +31,7 @@ export default function HomePage() {
                 </span>
               </div>
               <SocialsBar className="ml-auto hidden sm:flex" />
+              <SocialsSheet className="ml-auto sm:hidden" />
             </div>
             <span>
               This is a space for me to discuss software, photography,
@@ -55,7 +57,6 @@ export default function HomePage() {
                 );
               })}
             </div>
-            <SocialsBar className="my-2 justify-center sm:hidden" />
           </Scroll.Content>
         </Scroll.Container>
         <Abyss.Bottom />

--- a/src/atoms/drawer.tsx
+++ b/src/atoms/drawer.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import * as React from "react";
+import { Drawer as DrawerPrimitive } from "vaul";
+import { cn } from "@/utils";
+
+function Drawer({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+  return <DrawerPrimitive.Root data-slot="drawer" {...props} />;
+}
+
+function DrawerTrigger({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+  return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />;
+}
+
+function DrawerPortal({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+  return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />;
+}
+
+function DrawerClose({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+  return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />;
+}
+
+function DrawerOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+  return (
+    <DrawerPrimitive.Overlay
+      data-slot="drawer-overlay"
+      className={cn(
+        "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/10 backdrop-blur-sm",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DrawerContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+  return (
+    <DrawerPortal data-slot="drawer-portal">
+      <DrawerOverlay />
+      <DrawerPrimitive.Content
+        data-slot="drawer-content"
+        className={cn(
+          "group/drawer-content bg-background/80 fixed z-50 flex h-auto flex-col backdrop-blur-xl",
+          "data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b",
+          "data-[vaul-drawer-direction=bottom]:right-3 data-[vaul-drawer-direction=bottom]:bottom-3 data-[vaul-drawer-direction=bottom]:left-3 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-2xl data-[vaul-drawer-direction=bottom]:border data-[vaul-drawer-direction=bottom]:after:!hidden",
+          "data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",
+          "data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:sm:max-w-sm",
+          className,
+        )}
+        {...props}
+      >
+        <div className="bg-muted mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        {children}
+      </DrawerPrimitive.Content>
+    </DrawerPortal>
+  );
+}
+
+function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-header"
+      className={cn(
+        "flex flex-col gap-0.5 p-4 group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center group-data-[vaul-drawer-direction=top]/drawer-content:text-center md:gap-1.5 md:text-left",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  );
+}
+
+function DrawerTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+  return (
+    <DrawerPrimitive.Title
+      data-slot="drawer-title"
+      className={cn("text-foreground font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function DrawerDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+  return (
+    <DrawerPrimitive.Description
+      data-slot="drawer-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+};

--- a/src/features/socials/data.ts
+++ b/src/features/socials/data.ts
@@ -6,32 +6,39 @@ const socials = {
   github: {
     url: "https://github.com/bentsignal",
     icon: Icons.Github,
+    label: "@bentsignal",
   },
   x: {
     url: "https://x.com/bentsignal",
     icon: Icons.X,
+    label: "@bentsignal",
     className: "size-4.5",
   },
   instagram: {
     url: "https://www.instagram.com/bentsignal/",
     icon: Icons.Instagram,
+    label: "@bentsignal",
   },
   bluesky: {
     url: "https://bsky.app/profile/bentsignal.com",
     icon: Icons.Bluesky,
+    label: "@bentsignal.com",
   },
   discord: {
     url: "https://discord.gg/Ep9YsvhZ",
     icon: Icons.Discord,
+    label: "bentsignal",
     className: "size-6",
   },
   linkedin: {
     url: "https://www.linkedin.com/in/bentsignal/",
     icon: Icons.LinkedIn,
+    label: "bentsignal",
   },
   email: {
     url: "mailto:me@bentsignal.com",
     icon: MailIcon,
+    label: "me@bentsignal.com",
     className: "size-6",
   },
 } as const satisfies Record<Company, Metadata>;

--- a/src/features/socials/socials-sheet.tsx
+++ b/src/features/socials/socials-sheet.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import Link from "next/link";
+import { companies, socials } from "./data";
+import { Button } from "@/atoms/button";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@/atoms/drawer";
+import { cn } from "@/utils";
+
+const SocialsSheet = ({ className }: { className?: string }) => {
+  return (
+    <div className={className}>
+      <Drawer>
+        <DrawerTrigger asChild>
+          <Button variant="outline" size="sm">
+            Follow
+          </Button>
+        </DrawerTrigger>
+        <DrawerContent>
+          <DrawerTitle className="sr-only">Socials</DrawerTitle>
+          <div className="flex flex-col gap-1 px-4 pt-2 pb-4">
+            {companies.map((company) => {
+              const social = socials[company];
+              const Icon = social.icon;
+              return (
+                <Link
+                  key={company}
+                  href={social.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:bg-accent flex items-center gap-3 rounded-md px-3 py-2.5 transition-colors"
+                >
+                  <Icon
+                    className={cn(
+                      "size-5",
+                      (social as { className?: string }).className,
+                    )}
+                  />
+                  <div className="flex flex-col">
+                    <span className="text-sm font-medium capitalize">
+                      {company === "x" ? "X" : company}
+                    </span>
+                    <span className="text-muted-foreground text-xs">
+                      {social.label}
+                    </span>
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        </DrawerContent>
+      </Drawer>
+    </div>
+  );
+};
+
+export { SocialsSheet };

--- a/src/features/socials/types.ts
+++ b/src/features/socials/types.ts
@@ -10,6 +10,7 @@ type Company =
 type Metadata = {
   url: string;
   icon: React.ComponentType;
+  label: string;
   className?: string;
 };
 


### PR DESCRIPTION
## Summary
- Adds a Vaul-based drawer primitive for reusable mobile sheet interactions.
- Replaces the mobile socials bar with a `Follow` drawer trigger on the homepage.
- Shows each social link with an icon and label in the drawer, while keeping the desktop socials bar unchanged.
- Extends socials metadata with display labels for the new mobile layout.

## Testing
- Not run (PR content only).
- Expected checks for the code change: `pnpm run lint`, `pnpm run typecheck`, `pnpm run format:fix`.