### PR TITLE
Add animated starfield background to the layout

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -181,6 +181,16 @@
     linear-gradient(to top, #05133dff 0%, #01010eff 44%);
 }
 
+@keyframes twinkle {
+  0%,
+  100% {
+    opacity: var(--twinkle-min);
+  }
+  50% {
+    opacity: var(--twinkle-max);
+  }
+}
+
 .theme-afternoon {
   background:
     linear-gradient(to top, #ffffff00 0%, #090934ff 100%),

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter, Roboto_Mono } from "next/font/google";
 import type { Metadata } from "next";
 import * as Theme from "@/features/theme/atom";
 import { defaultTheme } from "@/features/theme/themes";
+import { Stars } from "@/atoms/stars";
 import { Toaster } from "@/atoms/toast";
 
 const inter = Inter({
@@ -43,6 +44,7 @@ export default function RootLayout({
           disableTransitionOnChange
           initialTheme={defaultTheme}
         >
+          <Stars />
           <Toaster />
           {children}
         </Theme.Store>

--- a/src/atoms/stars.tsx
+++ b/src/atoms/stars.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const TOTAL_NUM_STARS = 300;
+
+interface Star {
+  x: number;
+  y: number;
+  size: number;
+  color: string;
+  delay: number;
+  duration: number;
+}
+
+const STAR_COLORS = [
+  "rgba(255, 255, 255, 0.9)",
+  "rgba(255, 255, 255, 0.8)",
+  "rgba(255, 255, 255, 0.7)",
+  "rgba(255, 255, 255, 0.6)",
+  "rgba(200, 220, 255, 0.7)",
+  "rgba(200, 220, 255, 0.6)",
+  "rgba(255, 210, 180, 0.6)",
+  "rgba(255, 180, 180, 0.5)",
+];
+
+function generateStars(count: number): Star[] {
+  return Array.from({ length: count }, () => ({
+    x: Math.random() * 100,
+    y: Math.pow(Math.random(), 0.6) * 100,
+    size: Math.random() < 0.85 ? 1 : 1.5,
+    color: STAR_COLORS[Math.floor(Math.random() * STAR_COLORS.length)]!,
+    delay: Math.random() * 8,
+    duration: 2 + Math.random() * 4,
+  }));
+}
+
+export function Stars() {
+  const [stars, setStars] = useState<Star[]>([]);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    setStars(generateStars(TOTAL_NUM_STARS));
+    const timer = setTimeout(() => setVisible(true), 1500);
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (stars.length === 0) return null;
+
+  return (
+    <div
+      className="pointer-events-none fixed inset-0 z-0"
+      style={{
+        opacity: visible ? 1 : 0,
+        transition: "opacity 3s ease-in",
+      }}
+    >
+      {stars.map((star, i) => {
+        const t = star.y / 100;
+        const twinkleMin = 0.6 - t * 0.57;
+        const twinkleMax = 1.0 - t * 0.92;
+        return (
+          <div
+            key={i}
+            className="absolute rounded-full"
+            style={
+              {
+                left: `${star.x}%`,
+                top: `${star.y}%`,
+                width: star.size,
+                height: star.size,
+                backgroundColor: star.color,
+                "--twinkle-min": twinkleMin,
+                "--twinkle-max": twinkleMax,
+                animation: `twinkle ${star.duration}s ease-in-out ${star.delay}s infinite backwards`,
+              } as React.CSSProperties
+            }
+          />
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a client-side `Stars` overlay that renders 300 randomized twinkling stars.
- Fade the starfield in after initial load for a smoother entrance.
- Introduce a shared `twinkle` animation in global CSS and mount the overlay in the root layout.

## Testing
- Not run