### PR TITLE
Tighten mobile layout and extract React Scan

### DIFF
--- a/src/app/(posts)/[slug]/page.tsx
+++ b/src/app/(posts)/[slug]/page.tsx
@@ -66,7 +66,7 @@ export default async function Page({
             </div>
           </Scroll.Content>
         </Scroll.Container>
-        <div className="absolute right-0 bottom-0 z-6 flex flex-col gap-2 p-4">
+        <div className="absolute right-0 bottom-0 z-6 hidden flex-col gap-2 p-4 md:flex">
           <Scroll.ScrollToTopButton />
           <Scroll.ScrollToBottomButton />
         </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -133,6 +133,7 @@
   }
   body {
     @apply text-foreground font-sans;
+    min-height: 100vh;
   }
   code {
     @apply font-mono;
@@ -152,7 +153,24 @@
   );
 }
 
-.theme-space {
+html:has(.theme-space) {
+  background-color: #01010e;
+}
+
+html:has(.theme-afternoon) {
+  background-color: #090934;
+}
+
+body.theme-space::before,
+body.theme-afternoon::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+}
+
+body.theme-space::before {
   background:
     0% 99% / auto 50% no-repeat
       radial-gradient(
@@ -181,7 +199,7 @@
     linear-gradient(to top, #05133dff 0%, #01010eff 44%);
 }
 
-.theme-afternoon {
+body.theme-afternoon::before {
   background:
     linear-gradient(to top, #ffffff00 0%, #090934ff 100%),
     linear-gradient(to top, #b2d0f5ff 0%, #528bd1ff 30%, #091e2aff 70%);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import "./globals.css";
 import { Inter, Roboto_Mono } from "next/font/google";
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import * as Theme from "@/features/theme/atom";
 import { defaultTheme } from "@/features/theme/themes";
 import { Toaster } from "@/atoms/toast";
@@ -24,6 +24,10 @@ export const metadata: Metadata = {
   description: "A space for me to share my thoughts.",
 };
 
+export const viewport: Viewport = {
+  viewportFit: "cover",
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -31,11 +35,8 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className="dark" suppressHydrationWarning>
-      <head>
-        <ReactScan />
-      </head>
       <body
-        className={`${inter.variable} ${robotoMono.variable} ${defaultTheme.className} flex min-h-svh w-full overflow-y-hidden antialiased`}
+        className={`${inter.variable} ${robotoMono.variable} ${defaultTheme.className} w-full antialiased md:flex md:min-h-svh md:overflow-y-hidden`}
       >
         <Theme.Store
           attribute="class"
@@ -50,18 +51,3 @@ export default function RootLayout({
     </html>
   );
 }
-
-const ReactScan = () => {
-  if (process.env.NODE_ENV !== "development") {
-    return null;
-  }
-  return (
-    <>
-      {/* eslint-disable-next-line next/no-sync-scripts */}
-      <script
-        crossOrigin="anonymous"
-        src="//unpkg.com/react-scan/dist/auto.global.js"
-      />
-    </>
-  );
-};

--- a/src/atoms/abyss.tsx
+++ b/src/atoms/abyss.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@/utils";
 
-const shared = "bg-background/10 absolute z-5 flex pointer-events-none";
+const shared =
+  "bg-background/10 absolute z-5 hidden pointer-events-none md:flex";
 
 const verticalShared = "left-0 w-full h-16";
 const horizontalShared = "top-0 h-full w-16";

--- a/src/atoms/scroll/scroll-components.tsx
+++ b/src/atoms/scroll/scroll-components.tsx
@@ -15,7 +15,7 @@ const Wrapper = ({
   return (
     <div
       className={cn(
-        "relative flex max-h-screen flex-1 flex-col overflow-y-hidden",
+        "relative md:flex md:max-h-screen md:flex-1 md:flex-col md:overflow-y-hidden",
         className,
       )}
     >
@@ -41,18 +41,18 @@ const Container = ({
 
   const fadeClass =
     fade === "sm"
-      ? "mask-t-from-99% mask-b-from-99%"
+      ? "md:mask-t-from-99% md:mask-b-from-99%"
       : fade === "md"
-        ? "mask-t-from-97% mask-b-from-97%"
+        ? "md:mask-t-from-97% md:mask-b-from-97%"
         : fade === "lg"
-          ? "mask-t-from-95% mask-b-from-95%"
+          ? "md:mask-t-from-95% md:mask-b-from-95%"
           : undefined;
 
   return (
     <div
       className={cn(
-        "overflow-y-auto overscroll-contain",
-        "scrollbar-thin scrollbar-thumb-muted-foreground/10 scrollbar-track-transparent",
+        "md:overflow-y-auto md:overscroll-contain",
+        "md:scrollbar-thin md:scrollbar-thumb-muted-foreground/10 md:scrollbar-track-transparent",
         fadeClass,
         scrollbarClass,
       )}
@@ -152,7 +152,7 @@ const ProgressBar = () => {
   const percentToBottom = useScrollStore((s) => s.percentToBottom);
 
   return (
-    <div className="absolute top-0 right-0 z-6 w-full">
+    <div className="absolute top-0 right-0 z-6 hidden w-full md:block">
       <div
         className="bg-primary h-1"
         style={{ width: `${percentToBottom}%` }}

--- a/src/molecules/react-scan.tsx
+++ b/src/molecules/react-scan.tsx
@@ -1,0 +1,14 @@
+export const ReactScan = () => {
+  if (process.env.NODE_ENV !== "development") {
+    return null;
+  }
+  return (
+    <>
+      {/* eslint-disable-next-line next/no-sync-scripts */}
+      <script
+        crossOrigin="anonymous"
+        src="//unpkg.com/react-scan/dist/auto.global.js"
+      />
+    </>
+  );
+};


### PR DESCRIPTION
## Summary
- Moved the development-only React Scan script into `src/molecules/react-scan.tsx` and removed it from the root layout.
- Simplified the global layout and theme layering to better handle mobile viewport behavior.
- Adjusted scroll containers, abyss overlays, and post action controls to only apply desktop-only behavior on larger screens.
- Removed the socials drawer flow and unused star/drawer/social label code, while keeping the inline socials bar on mobile.

## Testing
- Not run
- Expected validation per repo instructions: `pnpm run lint`
- Expected validation per repo instructions: `pnpm run typecheck`
- Expected validation per repo instructions: `pnpm run format:fix`